### PR TITLE
Nested index limit

### DIFF
--- a/app/command/esBulk.ts
+++ b/app/command/esBulk.ts
@@ -92,6 +92,7 @@ const INDEX_SETTINGS = {
   number_of_replicas: 0,
   max_result_window: 10000000,
   'index.mapping.total_fields.limit': 10000,
+  'index.mapping.nested_objects.limit': 50000,
 }
 
 export const createDataEsIndex = async (


### PR DESCRIPTION
設定フィールド修正してbulkできることを確認しました。引っかかっていたのが dataType に20,000オブジェクトくらいを持っている patient だったので余裕持たせて50,000に設定してます